### PR TITLE
Fixed delta applied on the wrong values

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -237,15 +237,15 @@ pub struct SpectatorSettings {
     ///
     /// If `None`, the primary window will be used.
     pub active_window: Option<Entity>,
-    /// The base speed of the active [`Spectator`]. (Default: `0.1`)
+    /// The base speed of the active [`Spectator`]. (Default: `10.0`)
     ///
     /// Use this to control how fast the [`Spectator`] normally moves.
     pub base_speed: f32,
-    /// The alternate speed of the active [`Spectator`]. (Default: `0.5`)
+    /// The alternate speed of the active [`Spectator`]. (Default: `50.0`)
     ///
     /// Use this to control how fast the [`Spectator`] moves when you hold `Shift`.
     pub alt_speed: f32,
-    /// The camera sensitivity of the active [`Spectator`]. (Default: `0.1`)
+    /// The camera sensitivity of the active [`Spectator`]. (Default: `0.001`)
     ///
     /// Use this to control how fast the [`Spectator`] turns when you move the mouse.
     pub sensitivity: f32,
@@ -256,9 +256,9 @@ impl Default for SpectatorSettings {
         Self {
             active_spectator: None,
             active_window: None,
-            base_speed: 0.1,
-            alt_speed: 0.5,
-            sensitivity: 0.1,
+            base_speed: 10.0,
+            alt_speed: 50.0,
+            sensitivity: 0.001,
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -163,8 +163,8 @@ fn spectator_update(
                 total
             };
 
-            let mouse_x = -mouse_delta.x * time.delta_seconds() * settings.sensitivity;
-            let mouse_y = -mouse_delta.y * time.delta_seconds() * settings.sensitivity;
+            let mouse_x = -mouse_delta.x * settings.sensitivity;
+            let mouse_y = -mouse_delta.y * settings.sensitivity;
 
             let mut dof: Vec3 = camera_transform.rotation.to_euler(EulerRot::YXZ).into();
 
@@ -211,8 +211,9 @@ fn spectator_update(
             right.y = 0f32; // more of a sanity check
             let up = Vec3::Y;
 
-            camera_transform.translation +=
-                forward * delta_axial + right * delta_lateral + up * delta_vertical;
+            let result = forward * delta_axial + right * delta_lateral + up * delta_vertical;
+
+            camera_transform.translation += result * time.delta_seconds();
         }
     }
 


### PR DESCRIPTION
First of all thanks for this plugin, this saves me a lot of time for debugging!

I encountered an issue where camera rotation and speed were either too fast or too slow when I turned vsync on or off.
Rotation and translation were framerate dependant, camera sensitivity shouldn't be multiplied with the delta as the `MouseMotion` event values already represent the actual mouse speed, and the velocity should.

I tweaked the default values to accommodate the changes, but those are completely arbitrary as they were not fixed in the first place, let me know if the new ones seem good to you