### PR TITLE
Update to Bevy 0.12, bump to 0.4

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "bevy_spectator"
 description = "A spectator camera plugin for Bevy"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2021"
 authors = ["JonahPlusPlus <33059163+JonahPlusPlus@users.noreply.github.com>"]
 license = "MIT OR Apache-2.0"
@@ -11,10 +11,10 @@ repository = "https://github.com/JonahPlusPlus/bevy_spectator"
 exclude = ["/examples/"]
 
 [dependencies]
-bevy = { version = "0.11", default-features = false }
+bevy = { version = "0.12", default-features = false }
 
 [dev-dependencies]
-bevy = { version = "0.11", default-features = false, features = [
+bevy = { version = "0.12", default-features = false, features = [
   "bevy_asset",
   "bevy_core_pipeline",
   "bevy_pbr",

--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ fn setup(mut commands: Commands) {
 
 | bevy | bevy_spectator |
 |------|----------------|
+| 0.12 | 0.4            |
 | 0.11 | 0.3            |
 | 0.10 | 0.2            |
 | 0.9  | 0.1            |

--- a/examples/3d_scene.rs
+++ b/examples/3d_scene.rs
@@ -6,9 +6,9 @@ use bevy_spectator::*;
 fn main() {
     App::new()
         .insert_resource(SpectatorSettings {
-            base_speed: 0.05,
-            alt_speed: 0.2,
-            sensitivity: 0.05,
+            base_speed: 5.0,
+            alt_speed: 15.0,
+            sensitivity: 0.0015,
             ..default()
         })
         .add_plugins(DefaultPlugins)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -121,7 +121,7 @@ fn spectator_update(
         {
             let mouse_delta = {
                 let mut total = Vec2::ZERO;
-                for d in motion.iter() {
+                for d in motion.read() {
                     total += d.delta;
                 }
                 total

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -133,7 +133,7 @@ fn spectator_update(
             let mut dof: Vec3 = camera_transform.rotation.to_euler(EulerRot::YXZ).into();
 
             dof.x += mouse_x;
-            // At 90 degrees, yaw gets misinterpeted as roll. Making 89 the limit fixes that.
+            // At 90 degrees, yaw gets misinterpreted as roll. Making 89 the limit fixes that.
             dof.y = (dof.y + mouse_y).clamp(-89f32.to_radians(), 89f32.to_radians());
             dof.z = 0f32;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -92,7 +92,8 @@ fn spectator_update(
             window
         }
         None => {
-            let Some((window, _)) = windows.iter_mut().find(|(_, primary)| primary.is_some()) else {
+            let Some((window, _)) = windows.iter_mut().find(|(_, primary)| primary.is_some())
+            else {
                 panic!("No primary window found!");
             };
 


### PR DESCRIPTION
This PR updates the crate to bevy 0.12, and thus bumps it to 0.4.

The only change in the code was to update an `EventReader`'s `.iter()` to a `.read()` call.  
Other than that, only a minor spelling mistake was fixed.